### PR TITLE
Bump spring-security-version from 3.2.3.RELEASE to 5.1.6.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <!-- Описание версий фреймворков -->
     <properties>
         <spring-version>5.1.2.RELEASE</spring-version>
-        <spring-security-version>3.2.3.RELEASE</spring-security-version>
+        <spring-security-version>5.1.6.RELEASE</spring-security-version>
         <hibernate-version>4.3.11.Final</hibernate-version>
     </properties>
 


### PR DESCRIPTION
Bumps `spring-security-version` from 3.2.3.RELEASE to 5.1.6.RELEASE.

Updates `spring-security-config` from 3.2.3.RELEASE to 5.1.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/3.2.3.RELEASE...5.1.6.RELEASE)

Updates `spring-security-core` from 3.2.3.RELEASE to 5.1.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/3.2.3.RELEASE...5.1.6.RELEASE)

Updates `spring-security-web` from 3.2.3.RELEASE to 5.1.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/3.2.3.RELEASE...5.1.6.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>